### PR TITLE
Test Heroku Review Apps feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ android:
   - android-23
   - extra-android-m2repository
 before_install:
-- openssl aes-256-cbc -K $encrypted_caf26dd8a009_key -iv $encrypted_caf26dd8a009_iv
-  -in keys/evandroid.jks.enc -out keys/evandroid.jks -d
+#- openssl aes-256-cbc -K $encrypted_caf26dd8a009_key -iv $encrypted_caf26dd8a009_iv
+#  -in keys/evandroid.jks.enc -out keys/evandroid.jks -d
 - gem install fir-cli
 script:
 - ./gradlew assembleRelease

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # ContinuousDeploymentDemo
 [![Build Status](https://travis-ci.org/nggirl/ContinuousDeploymentDemo.svg?branch=master)](https://travis-ci.org/nggirl/ContinuousDeploymentDemo)
+
 基于Travis CI搭建Android持续集成以及自动打包发布流程


### PR DESCRIPTION
With [review apps](https://devcenter.heroku.com/articles/github-integration-review-apps) enabled for a Heroku app, Heroku will create temporary test apps for each pull-request that’s opened on the GitHub repo that’s connected to the parent app. Review apps are great if you’re using GitHub Flow to propose, discuss and merge changes to your code base. Because pull request branches are deployed to new apps on Heroku, it’s very simple for you and your collaborators to test and debug code branches. You can also run automated integration tests on the Heroku app representing a GitHub branch.
